### PR TITLE
Multiple line statement/expression support

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
         }
         let tokens = unsafe { tokens_result.unwrap_unchecked() };
 
-        let mut parser = Parser::new(tokens);
+        let mut parser = Parser::new(tokens, buffer.as_slice());
         let ast_result = parser.generate_syntax_tree();
 
         if let Err(err) = ast_result {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
 // this is a form of inport in JS
-use core::interpreter::{ExecutionContext, Interpret, SymbolTable, SymbolEntry, SymbolValue};
+use core::interpreter::{ExecutionContext, Interpret, SymbolEntry, SymbolTable, SymbolValue};
 use core::lexer::Lexer;
 use core::parser::Parser;
 
@@ -11,25 +11,45 @@ fn main() {
     print!("--------------------------------------\n");
 
     let global_symbol_table = SymbolTable::new(HashMap::from([
-        (String::from("true"), SymbolEntry {
-            value: SymbolValue::Bool(true),
-            is_constant: true,
-        }),
-        (String::from("false"), SymbolEntry {
-            value: SymbolValue::Bool(false),
-            is_constant: true,
-        })
+        (
+            String::from("true"),
+            SymbolEntry {
+                value: SymbolValue::Bool(true),
+                is_constant: true,
+            },
+        ),
+        (
+            String::from("false"),
+            SymbolEntry {
+                value: SymbolValue::Bool(false),
+                is_constant: true,
+            },
+        ),
     ]));
 
-    loop {
+    'repl: loop {
         print!("> ");
         io::stdout().flush().unwrap();
         let stdin = io::stdin();
         let mut handle = stdin.lock();
         // can only handle one line at a time right now
-        let ref mut buffer: Vec<u8> = Vec::new();
+        let mut buffer: Vec<u8> = Vec::new();
 
-        handle.read_until(b'\n', buffer).unwrap();
+        'read: loop {
+            let bytes = handle.read_until(b'\n', &mut buffer).unwrap();
+            if bytes <= 1 && buffer.len() == bytes {
+                // restart the repl loop when only a newline is in the buffer
+                continue 'repl;
+            } else if bytes == 1 {
+                // allow newline spacing
+                continue 'read;
+            }
+
+            if bytes >= 2 && buffer[buffer.len() - 2] != b';' {
+                // leave if there was no line termination char
+                break 'read;
+            }
+        }
 
         // set the io handle for reading the stream
         let mut reader = Lexer::new(&buffer);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,8 +10,8 @@ use core::parser::Parser;
 static REPL_EXEC: &str = ".exec\n";
 
 fn main() {
-    print!("T-Lang Console\n");
-    print!("--------------------------------------\n");
+    println!("T-Lang Console");
+    println!("--------------------------------------");
 
     let global_symbol_table = SymbolTable::new(HashMap::from([
         (
@@ -84,7 +84,7 @@ fn main() {
         let tokens_result = reader.parse_tokens();
 
         if let Err(err) = tokens_result {
-            print!("{}\n", err);
+            println!("{}", err);
             continue;
         }
         let tokens = unsafe { tokens_result.unwrap_unchecked() };
@@ -93,7 +93,7 @@ fn main() {
         let ast_result = parser.generate_syntax_tree();
 
         if let Err(err) = ast_result {
-            print!("{}\n", err);
+            println!("{}", err);
             continue;
         }
 
@@ -104,10 +104,10 @@ fn main() {
         );
         match ast.interpret(&mut context) {
             Ok(inter_type) => {
-                print!("= {}\n", inter_type);
+                println!("= {}", inter_type);
             }
             Err(err) => {
-                print!("{}\n", err);
+                println!("{}", err);
             }
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,9 @@ use std::io::{self, BufRead, Write};
 use core::interpreter::{ExecutionContext, Interpret, SymbolEntry, SymbolTable, SymbolValue};
 use core::lexer::Lexer;
 use core::parser::Parser;
+use std::ops::Range;
+
+static REPL_EXEC: &str = ".exec\n";
 
 fn main() {
     print!("T-Lang Console\n");
@@ -45,6 +48,14 @@ fn main() {
                 continue 'read;
             }
 
+            if bytes >= REPL_EXEC.len()
+                && &buffer[(buffer.len() - REPL_EXEC.len())..(buffer.len())] == REPL_EXEC.as_bytes()
+            {
+                for _ in 0..REPL_EXEC.len() {
+                    buffer.pop();
+                }
+                break 'read;
+            }
             if bytes >= 2 && buffer[buffer.len() - 2] != b';' {
                 // leave if there was no line termination char
                 break 'read;

--- a/core/src/interpreter/mod.rs
+++ b/core/src/interpreter/mod.rs
@@ -147,6 +147,7 @@ pub trait Interpret<'a> {
 impl<'a> Interpret<'a> for SyntaxNode {
     fn interpret(&self, context: &mut ExecutionContext) -> InterpreterResult {
         match self {
+            Self::Statements(node) => todo!("Implement the interpret trait for statement list"),
             Self::Variable(node) => node.interpret(context),
             Self::Factor(node) => node.interpret(context),
             Self::Unary(node) => node.interpret(context),
@@ -163,7 +164,7 @@ impl<'a> Interpret<'a> for VariableNode {
                     let expression = unsafe { self.expression.as_ref().unwrap_unchecked() };
                     let result = expression.interpret(context)?;
 
-                    context.visit(self.pos, self.identifier_token.source.start.line);
+                    context.visit(self.pos, self.line);
                     if let Err(err) = context
                         .symbol_table
                         .set(identifier, SymbolValue::from(&result))
@@ -173,7 +174,7 @@ impl<'a> Interpret<'a> for VariableNode {
 
                     Ok(result)
                 } else {
-                    context.visit(self.pos, self.identifier_token.source.start.line);
+                    context.visit(self.pos, self.line);
                     let value_result = context.symbol_table.get(identifier);
                     if value_result.is_none() {
                         let (start, end) = context.current_pos;
@@ -199,7 +200,7 @@ impl<'a> Interpret<'a> for VariableNode {
 
 impl<'a> Interpret<'a> for FactorNode {
     fn interpret(&self, context: &mut ExecutionContext) -> InterpreterResult {
-        context.visit(self.pos, self.token.source.start.line);
+        context.visit(self.pos, self.line);
 
         match self.token.value {
             TokenType::Int(int) => Ok(InterpretedType::Int(int)),
@@ -211,7 +212,7 @@ impl<'a> Interpret<'a> for FactorNode {
 
 impl<'a> Interpret<'a> for UnaryNode {
     fn interpret(&self, context: &mut ExecutionContext) -> InterpreterResult {
-        context.visit(self.pos, self.op_token.source.start.line);
+        context.visit(self.pos, self.line);
 
         match self.op_token.value {
             TokenType::Operation(OperationTokenType::Arithmetic(arith_type)) => {
@@ -231,7 +232,7 @@ impl<'a> Interpret<'a> for TermNode {
         let rhs = self.right_node.interpret(context)?;
 
         // set the term position after the children have finished
-        context.visit(self.pos, self.op_token.source.start.line);
+        context.visit(self.pos, self.line);
 
         match self.op_token.value {
             TokenType::Operation(OperationTokenType::Arithmetic(arith_type)) => {

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -5,7 +5,7 @@ use std::string::ToString;
 static KEYWORDS: &[&str] = &["let"];
 
 // Tokens structures
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Token {
     pub value: TokenType,
     pub source: Source,

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -99,7 +99,7 @@ impl ToString for LogicType {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Source {
     pub start: Position,
     pub end: Position,
@@ -139,7 +139,7 @@ impl Source {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct Position {
     pub index: usize,
     pub column: usize,

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -210,7 +210,7 @@ impl LexerError {
 /* lifetimes are important here because we need to define
 that the scope of the readable is where the methods are being called. */
 pub struct Lexer<'a> {
-    buffer: &'a Vec<u8>,
+    buffer: &'a [u8],
     pos: usize,
     byte: Option<&'a u8>,
     src: Position,
@@ -311,7 +311,7 @@ impl<'a> Iterator for Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
-    pub fn new(buf: &'a Vec<u8>) -> Lexer<'a> {
+    pub fn new(buf: &'a [u8]) -> Lexer<'a> {
         Lexer {
             buffer: buf,
             pos: 0,

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::vec::IntoIter;
 
 use crate::interpreter::{ExecutionContext, Interpret, InterpreterResult};
-use crate::lexer::{CompType, Location, LogicType, OperationTokenType, Token, TokenType};
+use crate::lexer::{CompType, Source, LogicType, OperationTokenType, Token, TokenType};
 
 pub enum ParseError {
     SyntaxError(IllegalSyntaxError),
@@ -27,7 +27,7 @@ pub struct IllegalSyntaxError {
 }
 
 impl IllegalSyntaxError {
-    fn new(name: &str, details: &str, location: Location, source: String) -> IllegalSyntaxError {
+    fn new(name: &str, details: &str, location: Source, source: String) -> IllegalSyntaxError {
         IllegalSyntaxError {
             name: name.to_string(),
             details: details.to_string(),
@@ -38,7 +38,7 @@ impl IllegalSyntaxError {
         }
     }
 
-    fn new_invalid_syntax(details: &str, location: Location, source: String) -> IllegalSyntaxError {
+    fn new_invalid_syntax(details: &str, location: Source, source: String) -> IllegalSyntaxError {
         Self::new(&"Illegal Syntax", details, location, source)
     }
 }
@@ -140,7 +140,7 @@ impl<'a> Interpret<'a> for AbstractSyntaxTree {
 
 struct DebugItem {
     value: String,
-    location: Location,
+    location: Source,
 }
 
 pub struct Parser {

--- a/core/src/parser/grammar.rs
+++ b/core/src/parser/grammar.rs
@@ -276,12 +276,13 @@ impl<'a> Parser<'a> {
 
         // LINETERM* statement
         self.skip_line_term(&mut context);
+        let line = (self.current_token.as_ref().unwrap()).source.start.line;
         let stmt = context.register(self.statement())?;
         let pos = stmt.get_pos();
         let statement = Statement {
             inner: Box::new(stmt),
             pos,
-            line: 0, // impl the line transfer
+            line, // impl the line transfer
         };
         let mut statements = vec![statement];
 
@@ -295,6 +296,7 @@ impl<'a> Parser<'a> {
                     break;
                 }
 
+                let line = (self.current_token.as_ref().unwrap()).source.start.line;
                 let stmt = match context.try_register(self.statement()) {
                     Ok(s) => s,
                     Err(Err(_)) => {
@@ -310,7 +312,7 @@ impl<'a> Parser<'a> {
                 let statement = Statement {
                     inner: Box::new(stmt),
                     pos,
-                    line: 0, // impl the line transfer
+                    line,
                 };
 
                 vec.push(statement);

--- a/core/src/parser/grammar.rs
+++ b/core/src/parser/grammar.rs
@@ -1,251 +1,12 @@
-use std::fmt::{Debug, Display, Formatter, Result as FormatResult};
 use std::mem;
-use std::vec::IntoIter;
 
-use crate::interpreter::{ExecutionContext, Interpret, InterpreterResult};
-use crate::lexer::{CompType, LogicType, OperationTokenType, Position, Source, Token, TokenType};
-
-pub enum ParseError {
-    SyntaxError(IllegalSyntaxError),
-}
-
-impl Display for ParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        match self {
-            ParseError::SyntaxError(err) => err.fmt(f),
-        }
-    }
-}
-
-pub struct IllegalSyntaxError {
-    pub name: String,
-    pub details: String,
-    pub source: String,
-    pub line: usize,
-    pub start: usize,
-    pub end: usize,
-}
-
-impl IllegalSyntaxError {
-    fn new(name: &str, details: &str, location: Source, source: String) -> IllegalSyntaxError {
-        IllegalSyntaxError {
-            name: name.to_string(),
-            details: details.to_string(),
-            source: source,
-            line: location.start.line,
-            start: location.start.column,
-            end: location.end.column,
-        }
-    }
-
-    fn new_invalid_syntax(details: &str, location: Source, source: &[u8]) -> IllegalSyntaxError {
-        let src = source.iter().map(|&b| b as char).collect();
-        Self::new("Illegal Syntax", details, location, src)
-    }
-}
-
-impl Display for IllegalSyntaxError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        let line_header = format!("line {line}: ", line = self.line);
-
-        let underline = (1..self.start + line_header.len())
-            .map(|_| ' ')
-            .chain((self.start..=self.end).map(|_| '^'))
-            .collect::<String>();
-
-        let source = self
-            .source
-            .lines()
-            .enumerate()
-            .skip_while(|(i, _)| i + 1 != self.line)
-            .map(|(_, line)| line)
-            .next()
-            .unwrap();
-
-        write!(
-            f,
-            "{name} - {details}\n\
-            {line_header}{source}\n\
-            {underline}",
-            name = self.name,
-            details = self.details
-        )
-    }
-}
-
-#[derive(Debug)]
-pub struct VariableNode {
-    pub identifier_token: Token,
-    pub expression: Option<Box<SyntaxNode>>,
-    pub assign: bool,
-    pub pos: (usize, usize),
-    pub line: usize,
-}
-
-#[derive(Debug)]
-pub struct FactorNode {
-    pub token: Token,
-    pub pos: (usize, usize),
-    pub line: usize,
-}
-
-#[derive(Debug)]
-pub struct UnaryNode {
-    pub op_token: Token,
-    pub node: Box<SyntaxNode>,
-    pub pos: (usize, usize),
-    pub line: usize,
-}
-
-#[derive(Debug)]
-pub struct TermNode {
-    pub op_token: Token,
-    pub left_node: Box<SyntaxNode>,
-    pub right_node: Box<SyntaxNode>,
-    pub pos: (usize, usize),
-    pub line: usize,
-}
-
-#[derive(Debug)]
-pub struct Statement {
-    pub inner: Box<SyntaxNode>,
-    pub pos: (usize, usize),
-    pub line: usize,
-}
-
-#[derive(Debug)]
-pub struct StatementList {
-    pub statements: Vec<Statement>,
-    pub pos: (usize, usize),
-}
-
-#[derive(Debug)]
-pub enum SyntaxNode {
-    Statements(StatementList),
-    Variable(VariableNode),
-    Factor(FactorNode),
-    Unary(UnaryNode),
-    Term(TermNode),
-}
-
-impl SyntaxNode {
-    fn get_pos(&self) -> (usize, usize) {
-        match self {
-            Self::Statements(node) => node.pos,
-            Self::Variable(node) => node.pos,
-            Self::Factor(node) => node.pos,
-            Self::Unary(node) => node.pos,
-            Self::Term(node) => node.pos,
-        }
-    }
-
-    fn set_pos(&mut self, pos: (usize, usize)) {
-        match self {
-            Self::Statements(node) => node.pos = pos,
-            Self::Variable(node) => node.pos = pos,
-            Self::Factor(node) => node.pos = pos,
-            Self::Unary(node) => node.pos = pos,
-            Self::Term(node) => node.pos = pos,
-        }
-    }
-}
-
-pub struct AbstractSyntaxTree {
-    inner: SyntaxNode,
-}
-
-impl Debug for AbstractSyntaxTree {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        write!(f, "{:#?}", self.inner)
-    }
-}
-
-impl<'a> Interpret<'a> for AbstractSyntaxTree {
-    fn interpret(&self, context: &mut ExecutionContext) -> InterpreterResult {
-        self.inner.interpret(context)
-    }
-}
-
-pub struct Parser<'a> {
-    source: &'a [u8],
-    tokens: IntoIter<Token>,
-    current_token: Option<Token>,
-}
-
-pub type ParseResult = Result<AbstractSyntaxTree, ParseError>;
-type InternalParseResult = Result<SyntaxNode, ParseError>;
-
-static EXPRESSION_OPS: [TokenType; 2] = [
-    TokenType::Operation(OperationTokenType::Arithmetic('+')),
-    TokenType::Operation(OperationTokenType::Arithmetic('-')),
-];
-static TERM_OPS: [TokenType; 2] = [
-    TokenType::Operation(OperationTokenType::Arithmetic('*')),
-    TokenType::Operation(OperationTokenType::Arithmetic('/')),
-];
+use crate::lexer::{CompType, LogicType, OperationTokenType, Token, TokenType};
+use crate::parser::{
+    FactorNode, IllegalSyntaxError, InternalParseResult, ParseError, Parser, Statement,
+    StatementList, SyntaxNode, UnaryNode, VariableNode,
+};
 
 impl<'a> Parser<'a> {
-    pub fn new(tokens: Vec<Token>, source: &'a [u8]) -> Parser<'a> {
-        let mut parser = Parser {
-            source,
-            tokens: tokens.into_iter(),
-            current_token: None,
-        };
-        parser.advance();
-
-        parser
-    }
-
-    fn advance(&mut self) {
-        let next = self.tokens.next();
-        self.current_token = next;
-    }
-
-    /**
-     * helper functions for parsing grammar nodes into the stacks
-     */
-    fn bin_op(
-        &mut self,
-        func: fn(&mut Parser) -> InternalParseResult,
-        ops: &[TokenType],
-    ) -> InternalParseResult {
-        let left_result = func(self);
-        if let Err(err) = left_result {
-            return Err(err);
-        }
-
-        let mut left = unsafe { left_result.unwrap_unchecked() };
-        while let Some(token) = &self.current_token {
-            if !ops.iter().any(|op| token.value == *op) {
-                break;
-            }
-
-            let op_token = mem::replace(&mut self.current_token, None).unwrap();
-            self.advance();
-
-            let right_result = func(self);
-            if let Err(err) = right_result {
-                return Err(err);
-            }
-            let right = unsafe { right_result.unwrap_unchecked() };
-
-            let (start, _) = left.get_pos();
-            let (_, end) = right.get_pos();
-            let pos = (start, end);
-            let line = op_token.source.start.line;
-
-            left = SyntaxNode::Term(TermNode {
-                left_node: Box::new(left),
-                right_node: Box::new(right),
-                op_token,
-                pos,
-                line,
-            });
-        }
-
-        Ok(left)
-    }
-
     /// atom = INT|FLOAT|IDENTIFIER
     ///      = LParen expression RParen
     fn atom(&mut self) -> InternalParseResult {
@@ -284,12 +45,7 @@ impl<'a> Parser<'a> {
                 let start = current_token.source.start.column;
                 self.advance();
 
-                let result = self.expression();
-                if let Err(err) = result {
-                    return Err(err);
-                }
-                let mut expression = unsafe { result.unwrap_unchecked() };
-
+                let mut expression = self.expression()?;
                 let token_ref = self.current_token.as_ref().unwrap();
                 let token_type = &token_ref.value;
                 let location = token_ref.source;
@@ -330,12 +86,7 @@ impl<'a> Parser<'a> {
                 let op_token = mem::replace(&mut self.current_token, None).unwrap();
                 self.advance();
 
-                let factor_result = self.factor();
-                if let Err(err) = factor_result {
-                    return Err(err);
-                }
-
-                let factor = unsafe { factor_result.unwrap_unchecked() };
+                let factor = self.factor()?;
                 let (_, end) = factor.get_pos();
                 let start = op_token.source.start.column;
                 let pos = (start, end);
@@ -354,13 +105,25 @@ impl<'a> Parser<'a> {
     /// term = factor (MUL|DIV factor)*
     fn term(&mut self) -> InternalParseResult {
         let func = |parser: &mut Parser| parser.factor();
-        self.bin_op(func, &TERM_OPS)
+        self.bin_op(
+            func,
+            &[
+                TokenType::Operation(OperationTokenType::Arithmetic('*')),
+                TokenType::Operation(OperationTokenType::Arithmetic('/')),
+            ],
+        )
     }
 
     /// arith_expr = term (PLUS|MINUS term)*
     fn arith_expr(&mut self) -> InternalParseResult {
         let func = |parser: &mut Parser| parser.term();
-        self.bin_op(func, &EXPRESSION_OPS)
+        self.bin_op(
+            func,
+            &[
+                TokenType::Operation(OperationTokenType::Arithmetic('+')),
+                TokenType::Operation(OperationTokenType::Arithmetic('-')),
+            ],
+        )
     }
 
     /// comp_expr = NOT comp_expr
@@ -374,12 +137,7 @@ impl<'a> Parser<'a> {
             let op_token = mem::replace(&mut self.current_token, None).unwrap();
             self.advance();
 
-            let cmp_expr = self.comp_expr();
-            if let Err(err) = cmp_expr {
-                return Err(err);
-            }
-
-            let node = Box::new(unsafe { cmp_expr.unwrap_unchecked() });
+            let node = Box::new(self.comp_expr()?);
             let pos = (op_token.source.start.column, node.get_pos().1);
             let line = op_token.source.start.line;
             Ok(SyntaxNode::Unary(UnaryNode {
@@ -474,12 +232,7 @@ impl<'a> Parser<'a> {
                     }
                 };
 
-                let expression_result = self.expr();
-                if let Err(err) = expression_result {
-                    return Err(err);
-                }
-
-                let expr = unsafe { expression_result.unwrap_unchecked() };
+                let expr = self.expr()?;
                 let pos = (let_token.source.start.column, expr.get_pos().1);
                 let line = let_token.source.start.line;
                 let expression = Some(Box::new(expr));
@@ -504,7 +257,7 @@ impl<'a> Parser<'a> {
     /// statements = LINETERM* statement
     ///             (LINETERM+ statement)*
     ///              LINETERM*
-    fn statements(&mut self) -> InternalParseResult {
+    pub fn statements(&mut self) -> InternalParseResult {
         // LINETERM* statement
         self.skip_line_term();
         let stmt = self.statement()?;
@@ -519,21 +272,22 @@ impl<'a> Parser<'a> {
         statements.append(&mut {
             let mut vec: Vec<Statement> = Vec::new();
             let mut more_statements = true;
-            
+
             // (LINETERM+ statement)*
             loop {
                 let (newlines, _) = self.skip_line_term();
                 if newlines == 0 {
                     more_statements = false;
                 }
-                
+
                 if !more_statements {
-                    break
+                    break;
                 }
                 let stmt = match self.statement() {
                     Ok(s) => s,
                     Err(e) => {
                         // because the LINETERM+ is not met, it moves to the next state
+                        return Err(e);
                         todo!()
                     }
                 };
@@ -558,49 +312,5 @@ impl<'a> Parser<'a> {
             statements,
             pos: list_pos,
         }))
-    }
-
-    fn skip_line_term(&mut self) -> (usize, Source) {
-        let mut newlines = 0;
-        let mut last_source = Source::default();
-
-        while let Some(Token {
-            value: TokenType::LineTerm,
-            source,
-        }) = self.current_token
-        {
-            last_source = source;
-            self.advance();
-            newlines += 1;
-        }
-
-        if let Some(token) = &self.current_token {
-            last_source = token.source;
-        }
-
-        (newlines, last_source)
-    }
-
-    pub fn generate_syntax_tree(&mut self) -> ParseResult {
-        let result = self.statements();
-        let current_token = self.current_token.as_ref().unwrap();
-        let token_type = &current_token.value;
-        let token_location = current_token.source;
-
-        match result {
-            Ok(node) if matches!(token_type, &TokenType::EOF) => {
-                Ok(AbstractSyntaxTree { inner: node })
-            }
-            Err(err) => Err(err),
-            _ => {
-                return Err(ParseError::SyntaxError(
-                    IllegalSyntaxError::new_invalid_syntax(
-                        "Expected '+', '-', '*', '/'",
-                        token_location,
-                        self.source,
-                    ),
-                ));
-            }
-        }
     }
 }

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Debug, Display, Formatter, Result as FormatResult};
 use std::mem;
-use std::vec::IntoIter;
 
 use crate::interpreter::{ExecutionContext, Interpret, InterpreterResult};
 use crate::lexer::{Position, Source, Token, TokenType};

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -1,0 +1,282 @@
+use std::fmt::{Debug, Display, Formatter, Result as FormatResult};
+use std::mem;
+use std::vec::IntoIter;
+
+use crate::interpreter::{ExecutionContext, Interpret, InterpreterResult};
+use crate::lexer::{CompType, LogicType, OperationTokenType, Position, Source, Token, TokenType};
+
+pub enum ParseError {
+    SyntaxError(IllegalSyntaxError),
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
+        match self {
+            ParseError::SyntaxError(err) => err.fmt(f),
+        }
+    }
+}
+
+pub struct IllegalSyntaxError {
+    pub name: String,
+    pub details: String,
+    pub source: String,
+    pub location: Source
+}
+
+impl IllegalSyntaxError {
+    fn new(name: &str, details: &str, location: Source, source: String) -> IllegalSyntaxError {
+        IllegalSyntaxError {
+            name: name.to_string(),
+            details: details.to_string(),
+            source,
+            location,
+        }
+    }
+
+    fn new_invalid_syntax(details: &str, location: Source, source: &[u8]) -> IllegalSyntaxError {
+        let src = source.iter().map(|&b| b as char).collect();
+        Self::new("Illegal Syntax", details, location, src)
+    }
+}
+
+impl Display for IllegalSyntaxError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
+        let line_header = format!("line {line}: ", line = self.location.start.line);
+
+        let underline = (1..self.location.start.column + line_header.len())
+            .map(|_| ' ')
+            .chain((self.location.start.column..=self.location.end.column).map(|_| '^'))
+            .collect::<String>();
+
+        let source = self
+            .source
+            .lines()
+            .enumerate()
+            .skip_while(|(i, _)| i + 1 != self.location.start.line)
+            .map(|(_, line)| line)
+            .next()
+            .unwrap();
+
+        write!(
+            f,
+            "{name} - {details}\n\
+            {line_header}{source}\n\
+            {underline}",
+            name = self.name,
+            details = self.details
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct VariableNode {
+    pub identifier_token: Token,
+    pub expression: Option<Box<SyntaxNode>>,
+    pub assign: bool,
+    pub pos: (usize, usize),
+    pub line: usize,
+}
+
+#[derive(Debug)]
+pub struct FactorNode {
+    pub token: Token,
+    pub pos: (usize, usize),
+    pub line: usize,
+}
+
+#[derive(Debug)]
+pub struct UnaryNode {
+    pub op_token: Token,
+    pub node: Box<SyntaxNode>,
+    pub pos: (usize, usize),
+    pub line: usize,
+}
+
+#[derive(Debug)]
+pub struct TermNode {
+    pub op_token: Token,
+    pub left_node: Box<SyntaxNode>,
+    pub right_node: Box<SyntaxNode>,
+    pub pos: (usize, usize),
+    pub line: usize,
+}
+
+#[derive(Debug)]
+pub struct Statement {
+    pub inner: Box<SyntaxNode>,
+    pub pos: (usize, usize),
+    pub line: usize,
+}
+
+#[derive(Debug)]
+pub struct StatementList {
+    pub statements: Vec<Statement>,
+    pub pos: (usize, usize),
+}
+
+#[derive(Debug)]
+pub enum SyntaxNode {
+    Statements(StatementList),
+    Variable(VariableNode),
+    Factor(FactorNode),
+    Unary(UnaryNode),
+    Term(TermNode),
+}
+
+impl SyntaxNode {
+    fn get_pos(&self) -> (usize, usize) {
+        match self {
+            Self::Statements(node) => node.pos,
+            Self::Variable(node) => node.pos,
+            Self::Factor(node) => node.pos,
+            Self::Unary(node) => node.pos,
+            Self::Term(node) => node.pos,
+        }
+    }
+
+    fn set_pos(&mut self, pos: (usize, usize)) {
+        match self {
+            Self::Statements(node) => node.pos = pos,
+            Self::Variable(node) => node.pos = pos,
+            Self::Factor(node) => node.pos = pos,
+            Self::Unary(node) => node.pos = pos,
+            Self::Term(node) => node.pos = pos,
+        }
+    }
+}
+
+pub struct AbstractSyntaxTree {
+    inner: SyntaxNode,
+}
+
+impl Debug for AbstractSyntaxTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
+        write!(f, "{:#?}", self.inner)
+    }
+}
+
+impl<'a> Interpret<'a> for AbstractSyntaxTree {
+    fn interpret(&self, context: &mut ExecutionContext) -> InterpreterResult {
+        self.inner.interpret(context)
+    }
+}
+
+pub struct Parser<'a> {
+    source: &'a [u8],
+    tokens: IntoIter<Token>,
+    current_token: Option<Token>,
+}
+
+pub type ParseResult = Result<AbstractSyntaxTree, ParseError>;
+type InternalParseResult = Result<SyntaxNode, ParseError>;
+
+mod grammar;
+
+impl<'a> Parser<'a> {
+
+    pub fn new(tokens: Vec<Token>, source: &'a [u8]) -> Parser<'a> {
+        let mut parser = Parser {
+            source,
+            tokens: tokens.into_iter(),
+            current_token: None,
+        };
+        parser.advance();
+
+        parser
+    }
+
+    fn advance(&mut self) {
+        let next = self.tokens.next();
+        self.current_token = next;
+    }
+
+    /**
+     * helper functions for parsing grammar nodes into the stacks
+     */
+    fn bin_op(
+        &mut self,
+        func: fn(&mut Parser) -> InternalParseResult,
+        ops: &[TokenType],
+    ) -> InternalParseResult {
+        let left_result = func(self);
+        if let Err(err) = left_result {
+            return Err(err);
+        }
+
+        let mut left = unsafe { left_result.unwrap_unchecked() };
+        while let Some(token) = &self.current_token {
+            if !ops.iter().any(|op| token.value == *op) {
+                break;
+            }
+
+            let op_token = mem::replace(&mut self.current_token, None).unwrap();
+            self.advance();
+
+            let right_result = func(self);
+            if let Err(err) = right_result {
+                return Err(err);
+            }
+            let right = unsafe { right_result.unwrap_unchecked() };
+
+            let (start, _) = left.get_pos();
+            let (_, end) = right.get_pos();
+            let pos = (start, end);
+            let line = op_token.source.start.line;
+
+            left = SyntaxNode::Term(TermNode {
+                left_node: Box::new(left),
+                right_node: Box::new(right),
+                op_token,
+                pos,
+                line,
+            });
+        }
+
+        Ok(left)
+    }
+
+    fn skip_line_term(&mut self) -> (usize, Source) {
+        let mut newlines = 0;
+        let mut last_source = Source::default();
+
+        while let Some(Token {
+            value: TokenType::LineTerm,
+            source,
+        }) = self.current_token
+        {
+            last_source = source;
+            self.advance();
+            newlines += 1;
+        }
+
+        if let Some(token) = &self.current_token {
+            last_source = token.source;
+        }
+
+        (newlines, last_source)
+    }
+
+    pub fn generate_syntax_tree(&mut self) -> ParseResult {
+        let result = self.statements();
+        let current_token = self.current_token.as_ref().unwrap();
+        let token_type = &current_token.value;
+        let token_location = current_token.source;
+
+        match result {
+            Ok(node) if matches!(token_type, &TokenType::EOF) => {
+                Ok(AbstractSyntaxTree { inner: node })
+            }
+            Err(err) => Err(err),
+            _ => {
+                return Err(ParseError::SyntaxError(
+                    IllegalSyntaxError::new_invalid_syntax(
+                        "Expected '+', '-', '*', '/'",
+                        token_location,
+                        self.source,
+                    ),
+                ));
+            }
+        }
+    }
+}

--- a/parser.md
+++ b/parser.md
@@ -7,7 +7,7 @@ This is used to restrict what is allowed to be used for programming purposes.
 
 # Grammar rules
 ```
-statements = LINETERM* statement (LINETERM+ statement) LINETERM*
+statements = LINETERM* statement (LINETERM+ statement)* LINETERM*
 
 statement  = expression
 

--- a/parser.md
+++ b/parser.md
@@ -7,6 +7,10 @@ This is used to restrict what is allowed to be used for programming purposes.
 
 # Grammar rules
 ```
+statements = LINETERM* statement (LINETERM+ statement) LINETERM*
+
+statement  = expression
+
 expression = KW:LET IDENTIFIER EQ expr 
            = expr
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -25,7 +25,8 @@ lazy_static! {
 pub fn run(source: &str) -> String {
     utils::set_panic_hook();
 
-    let buffer = Vec::from(source.as_bytes());
+    let bytes = source.as_bytes();
+    let buffer = Vec::from(source);
 
     // set the io handle for reading the stream
     let mut reader = Lexer::new(&buffer);
@@ -36,7 +37,7 @@ pub fn run(source: &str) -> String {
     }
     let tokens = unsafe { tokens_result.unwrap_unchecked() };
 
-    let mut parser = Parser::new(tokens);
+    let mut parser = Parser::new(tokens, bytes);
     let ast_result = parser.generate_syntax_tree();
 
     if let Err(err) = ast_result {


### PR DESCRIPTION
# Description
The language now allows for more than 1 line to be interpreted.

# Grammar changes
```
statements = LINETERM* statement (LINETERM+ statement) LINETERM*

statement  = expression
```

# CLI changes
 - adding `\` to the end of the cli input will continue the read loop
 - inputting `.exec` will break the read loop and execute the buffered input.